### PR TITLE
ASTON ONLY! Functional edit items

### DIFF
--- a/src/components/common/addItem.js
+++ b/src/components/common/addItem.js
@@ -39,9 +39,9 @@ const useStyles = makeStyles(theme => ({
 const initialValues = {
   itemName: '',
   description: '',
-  price: undefined,
-  marketId: undefined,
-  productId: undefined,
+  price: '',
+  marketId: '',
+  productId: '',
 };
 
 const initialFormErrors = {
@@ -120,7 +120,7 @@ const AddItem = ({ products, markets }) => {
     axiosWithAuth()
       .post('/item', newItem)
       .then(res => {
-        console.log('AddItem post success', res.data);
+        console.log('AddItem post success', res.header);
         setItem(initialValues);
       })
       .catch(err => console.log('AddItem post failed', err.response));
@@ -190,6 +190,7 @@ const AddItem = ({ products, markets }) => {
             value={item.marketId}
             onChange={handleChange}
           >
+            <MenuItem value="">Select a market</MenuItem>
             {markets.map(market => (
               <MenuItem key={market.marketId} value={market.marketId}>
                 {market.name}
@@ -207,6 +208,7 @@ const AddItem = ({ products, markets }) => {
             value={item.productId}
             onChange={handleChange}
           >
+            <MenuItem value="">Select a product</MenuItem>
             {products.map(product => (
               <MenuItem key={product.product_id} value={product.product_id}>
                 {product.product_name}

--- a/src/components/common/userItemsLIsted.js
+++ b/src/components/common/userItemsLIsted.js
@@ -32,8 +32,12 @@ const initialEditItem = {
   name: '',
   description: '',
   price: '',
-  market: '',
-  product: '',
+  market: {
+    marketId: undefined,
+  },
+  product: {
+    productId: undefined,
+  },
 };
 
 const UserItemsListed = ({ updateItems, userItemsList, products, markets }) => {
@@ -47,11 +51,37 @@ const UserItemsListed = ({ updateItems, userItemsList, products, markets }) => {
   }
 
   const saveEdited = e => {
-    console.log('this is save edit', saveEdited);
     e.preventDefault();
+    const newItem = {
+      name: itemToEdit.itemName,
+      description: itemToEdit.description,
+      price: parseFloat(itemToEdit.price),
+      market: { marketId: itemToEdit.marketId },
+      product: { productId: itemToEdit.productId },
+    };
+    console.log('this is itemToEdit', itemToEdit);
+    console.log(itemToEdit.itemId);
     axiosWithAuth()
-      .patch(`/item/${itemToEdit.id}`, itemToEdit)
-      .then(res => {
+      .patch('/item/1', newItem)
+      // console.log("this means axioswithAUth is being hit")
+      .then(
+        res => console.log('this should go', res)
+        // console.log('patch success', res.headers);
+        // updateItems([
+        //   ...userItemsList.map(item => {
+        //     if (item.id === itemToEdit.id) {
+        //       return itemToEdit;
+        //     } else {
+        //       return item;
+        //     }
+        //   }),
+        // ]);
+        // console.log("this should be update", itemToEdit);
+      )
+      .catch(err => {
+        console.error('Error in Edit');
+      })
+      .finally(
         updateItems([
           ...userItemsList.map(item => {
             if (item.id === itemToEdit.id) {
@@ -60,11 +90,8 @@ const UserItemsListed = ({ updateItems, userItemsList, products, markets }) => {
               return item;
             }
           }),
-        ]);
-      })
-      .catch(err => {
-        console.error('Error in Edit');
-      });
+        ])
+      );
   };
 
   const deleteItem = item => {
@@ -151,8 +178,14 @@ const UserItemsListed = ({ updateItems, userItemsList, products, markets }) => {
               label="Select"
               helperText="Select market location"
               variant="outlined"
-              name="market"
-              value={itemToEdit.market}
+              name="marketId"
+              value={itemToEdit.marketId}
+              onChange={e =>
+                setItemToEdit({
+                  ...itemToEdit,
+                  market: { marketId: e.target.value },
+                })
+              }
             >
               {markets.map(market => (
                 <MenuItem key={market.marketId} value={market.marketId}>
@@ -166,12 +199,18 @@ const UserItemsListed = ({ updateItems, userItemsList, products, markets }) => {
               label="Select"
               helperText="Select product"
               variant="outlined"
-              name="product"
-              value={itemToEdit.product}
+              name="productId"
+              value={itemToEdit.productId}
+              onChange={e =>
+                setItemToEdit({
+                  ...itemToEdit,
+                  product: { productId: e.target.value },
+                })
+              }
             >
-              {products.map(product => (
-                <MenuItem key={product.product_id} value={product.product_id}>
-                  {product.product_name}
+              {products.map(prod => (
+                <MenuItem key={prod.product_id} value={prod.product_id}>
+                  {prod.product_name}
                 </MenuItem>
               ))}
             </TextField>

--- a/src/components/common/userItemsLIsted.js
+++ b/src/components/common/userItemsLIsted.js
@@ -32,11 +32,13 @@ const initialEditItem = {
   name: '',
   description: '',
   price: '',
+  // marketId: undefined,
+  // productId: undefined
   market: {
-    marketId: undefined,
+    marketId: '',
   },
   product: {
-    productId: undefined,
+    productId: '',
   },
 };
 
@@ -46,42 +48,25 @@ const UserItemsListed = ({ updateItems, userItemsList, products, markets }) => {
   const [itemToEdit, setItemToEdit] = useState(initialEditItem);
 
   function editItem(item) {
-    console.log('this is the editing item', item);
+    // console.log('this is the editing item', item);
     setItemToEdit(item);
   }
 
   const saveEdited = e => {
     e.preventDefault();
     const newItem = {
-      name: itemToEdit.itemName,
+      name: itemToEdit.name,
       description: itemToEdit.description,
       price: parseFloat(itemToEdit.price),
-      market: { marketId: itemToEdit.marketId },
-      product: { productId: itemToEdit.productId },
+      market: { marketId: itemToEdit.market.marketId },
+      product: { productId: itemToEdit.product.productId },
     };
-    console.log('this is itemToEdit', itemToEdit);
-    console.log(itemToEdit.itemId);
+    // console.log('this is itemToEdit', itemToEdit);
+
     axiosWithAuth()
-      .patch('/item/1', newItem)
-      // console.log("this means axioswithAUth is being hit")
-      .then(
-        res => console.log('this should go', res)
+      .patch(`/item/${itemToEdit.itemId}`, newItem)
+      .then(res => {
         // console.log('patch success', res.headers);
-        // updateItems([
-        //   ...userItemsList.map(item => {
-        //     if (item.id === itemToEdit.id) {
-        //       return itemToEdit;
-        //     } else {
-        //       return item;
-        //     }
-        //   }),
-        // ]);
-        // console.log("this should be update", itemToEdit);
-      )
-      .catch(err => {
-        console.error('Error in Edit');
-      })
-      .finally(
         updateItems([
           ...userItemsList.map(item => {
             if (item.id === itemToEdit.id) {
@@ -90,8 +75,12 @@ const UserItemsListed = ({ updateItems, userItemsList, products, markets }) => {
               return item;
             }
           }),
-        ])
-      );
+        ]);
+        // console.log("this should be update", itemToEdit);
+      })
+      .catch(err => {
+        console.error('Error in Edit');
+      });
   };
 
   const deleteItem = item => {
@@ -108,10 +97,10 @@ const UserItemsListed = ({ updateItems, userItemsList, products, markets }) => {
       <h1>Here's the items you currently have for sale!</h1>
       <ul>
         {userItemsList.map(item => (
-          <li key={item.id} onClick={() => editItem(item)}>
+          <li key={item.itemId} onClick={() => editItem(item)}>
             <span>
               <span
-                onclick={e => {
+                onClick={e => {
                   e.stopPropagation();
                   deleteItem(item);
                 }}
@@ -138,7 +127,7 @@ const UserItemsListed = ({ updateItems, userItemsList, products, markets }) => {
               id="outlined-basic"
               label="Item Name"
               variant="outlined"
-              name="itemName"
+              name="name"
               placeholder="REQUIRED"
               value={itemToEdit.name}
               onChange={e =>
@@ -179,7 +168,7 @@ const UserItemsListed = ({ updateItems, userItemsList, products, markets }) => {
               helperText="Select market location"
               variant="outlined"
               name="marketId"
-              value={itemToEdit.marketId}
+              value={itemToEdit.market.marketId}
               onChange={e =>
                 setItemToEdit({
                   ...itemToEdit,
@@ -187,12 +176,14 @@ const UserItemsListed = ({ updateItems, userItemsList, products, markets }) => {
                 })
               }
             >
+              <MenuItem value="">Pick A Market</MenuItem>
               {markets.map(market => (
                 <MenuItem key={market.marketId} value={market.marketId}>
                   {market.name}
                 </MenuItem>
               ))}
             </TextField>
+
             <TextField
               id="select-product"
               select
@@ -200,7 +191,7 @@ const UserItemsListed = ({ updateItems, userItemsList, products, markets }) => {
               helperText="Select product"
               variant="outlined"
               name="productId"
-              value={itemToEdit.productId}
+              value={itemToEdit.product.productId}
               onChange={e =>
                 setItemToEdit({
                   ...itemToEdit,
@@ -208,6 +199,7 @@ const UserItemsListed = ({ updateItems, userItemsList, products, markets }) => {
                 })
               }
             >
+              <MenuItem value="">Pick a product</MenuItem>
               {products.map(prod => (
                 <MenuItem key={prod.product_id} value={prod.product_id}>
                   {prod.product_name}

--- a/src/components/pages/userPage.js
+++ b/src/components/pages/userPage.js
@@ -19,9 +19,12 @@ const UserPage = ({ getData }) => {
   };
 
   useEffect(() => {
-    getUserItems();
     getData();
   }, [getData]);
+
+  useEffect(() => {
+    getUserItems();
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
ONLY ASHTON CAN MERGE THIS!
This used your `useritems-update`branch as a base. So I started with what you had last pushed up. (If you merge this, delete your old branch. Or update your old branch to the fixes in here & delete this one if you really wanna understand the changes deep in your bones. My skull aches now though, so be ye careful.)
- The editItem dropdowns weren't pre-populating bc we weren't setting the right value to them, and by setting them to undefined in their initial state I originally created a controlled component when it should have been uncontrolled (or visa-versa, it's late & my brain mushed a bit). There's now an empty string as initial state & that empty string actually corresponds to a "Please choose a market/product" dropdown option to minimize warnings and make everything work even better.
- The patch wasn't working at all originally bc some magic I still don't entirely understand, but I accidentally fixed just before putting every key in quotes. My mentor made me undo the quotes to prove that was not the solution. Still not sure what it was. But we then redid variable names and shape throughout to get the patch to send up exactly what we wanted.
- The logic inside the .then still needs to be fixed, it's setting all the userItemsList wierd, like ya saw. I vote just forcing a new axios call from the server at that point, since it's the most up-to-date data (on the odd chance 2 people share the same account details and both add/edit things. 
-we activated the onClick on the delete button. It was originally `onclick` & not working. Dunno if that was intentional bc you didn't want to delete the single item originally, or accidental, but it's live now. Didn't test delete funcionality.